### PR TITLE
[stable33] ci(deps): bump actions/checkout from 5.0.0 to 6.0.2

### DIFF
--- a/.github/workflows/composer-auto.yml
+++ b/.github/workflows/composer-auto.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check vendor changes
     steps:
     - name: Checkout
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Manual backport of #35 because /backport did not create PR.